### PR TITLE
fix TypeError: 'NoneType' object is not subscriptable in issue 448

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -347,7 +347,10 @@ class Dataset_Pred(Dataset):
         
         df_stamp = pd.DataFrame(columns = ['date'])
         df_stamp.date = list(tmp_stamp.date.values) + list(pred_dates[1:])
-        data_stamp = time_features(df_stamp, timeenc=self.timeenc, freq=self.freq[-1:])
+        if self.freq is None:
+            data_stamp = time_features(df_stamp, timeenc=self.timeenc, freq=self.freq)
+        else:
+            data_stamp = time_features(df_stamp, timeenc=self.timeenc, freq=self.freq[-1:])
 
         self.data_x = data[border1:border2]
         if self.inverse:


### PR DESCRIPTION
Added a condition trying to avoid the problem described in issue 448 (https://github.com/zhouhaoyi/Informer2020/issues/448) (TypeError: 'NoneType' object is not subscriptable). The problem occurred because of the self.freq is None and the original code was trying to index into the None type.